### PR TITLE
only use GITHUB_TOKEN when it is defined

### DIFF
--- a/tasks/clone.py
+++ b/tasks/clone.py
@@ -13,9 +13,23 @@ from .common import (REPO_BASE_URL, CLONE_DIR_PATH,
 LOGGER = get_logger('CLONE')
 
 
-def clone_url(owner, repository, access_token):
-    '''Creates a URL to a remote git repository'''
-    return f'https://{access_token}@{REPO_BASE_URL}/{owner}/{repository}.git'
+def clone_url(owner, repository, access_token=''):
+    '''
+    Creates a URL to a remote git repository.
+    If `access_token` is specified, it will be included in the authentication
+    section of the returned URL.
+
+    >>> clone_url('owner', 'repo')
+    'https://github.com/owner/repo.git'
+
+    >>> clone_url('owner2', 'repo2', 'secret-token')
+    'https://secret-token@github.com/owner2/repo2.git'
+    '''
+    repo_url = f'{REPO_BASE_URL}/{owner}/{repository}.git'
+    if access_token:
+        repo_url = f'{access_token}@{repo_url}'
+
+    return f'https://{repo_url}'
 
 
 def _clone_repo(ctx, owner, repository, branch):

--- a/tasks/main.py
+++ b/tasks/main.py
@@ -102,14 +102,22 @@ def main(ctx):
 
     AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
     AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
-    GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
 
     # List of private strings to be removed from any posted logs
-    private_values = [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN]
+    private_values = [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]
 
     # Optional environment variables
-    SOURCE_REPO = os.getenv('SOURCE_REPO')
-    SOURCE_OWNER = os.getenv('SOURCE_OWNER')
+    SOURCE_REPO = os.getenv('SOURCE_REPO', '')
+    SOURCE_OWNER = os.getenv('SOURCE_OWNER', '')
+
+    # GITHUB_TOKEN can be empty if a non-Federalist user
+    # makes a commit to a repo and thus initiates a build for a
+    # Federalist site
+    GITHUB_TOKEN = os.getenv('GITHUB_TOKEN', '')
+    if GITHUB_TOKEN:
+        # only include it in list of values to strip from log output
+        # if it exists
+        private_values.append(GITHUB_TOKEN)
 
     # Ex: https://federalist-builder.fr.cloud.gov/builds/<token>/callback
     FEDERALIST_BUILDER_CALLBACK = os.environ['FEDERALIST_BUILDER_CALLBACK']


### PR DESCRIPTION
And thus only scrub it from logs when it it isn't blank. Ref #12 